### PR TITLE
Add MOVES_COUNT and NUM_SPECIES to RHH rom header

### DIFF
--- a/src/rom_header_rhh.c
+++ b/src/rom_header_rhh.c
@@ -1,5 +1,7 @@
 #include "global.h"
 #include "constants/expansion.h"
+#include "constants/moves.h"
+#include "constants/species.h"
 
 // Similar to the GF ROM header, this struct allows external programs to
 // detect details about Expansion.
@@ -14,6 +16,8 @@ struct RHHRomHeader
     /*0x07*/ u8 expansionVersionMinor;
     /*0x08*/ u8 expansionVersionPatch;
     /*0x09*/ u8 expansionVersionFlags;
+    /*0x0A*/ int expansionMovesCount;
+    /*0x0B*/ int expansionMonCount;
 };
 
 static const struct RHHRomHeader sRHHRomHeader =
@@ -23,4 +27,6 @@ static const struct RHHRomHeader sRHHRomHeader =
     .expansionVersionMinor = EXPANSION_VERSION_MINOR,
     .expansionVersionPatch = EXPANSION_VERSION_PATCH,
     .expansionVersionFlags = (EXPANSION_TAGGED_RELEASE << 0),
+    .expansionMovesCount = MOVES_COUNT,
+    .expansionMonCount = NUM_SPECIES,
 };


### PR DESCRIPTION
## Description
This PR adds the MOVES_COUNT and NUM_SPECIES values to the RHH rom header, to provide ease of access to these informations to external software

## Issue(s) that this PR fixes
fixes #3829

## Feature(s) this PR does NOT handle:
Documentation on how to use the RHH rom header from an external software

## **Discord contact info**
ninjdai
